### PR TITLE
Add documentation and minor naming changes to fractional coordinate system implementation

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -182,4 +182,5 @@ epub_exclude_files = ['search.html']
 # -- Options for intersphinx extension ---------------------------------------
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {'python': ('https://docs.python.org/', None),
+                       'numpy': ('https://numpy.readthedocs.io/en/latest/', None)}

--- a/doc/reference/kristal.geometry.rst
+++ b/doc/reference/kristal.geometry.rst
@@ -1,0 +1,8 @@
+kristal.geometry
+=================
+
+.. automodule :: kristal.geometry
+     :members:
+
+.. automodule :: kristal.geometry.equiv
+     :members:

--- a/doc/reference/kristal.rst
+++ b/doc/reference/kristal.rst
@@ -4,3 +4,4 @@ Modules
 .. toctree::
 
    kristal.io
+   kristal.geometry

--- a/kristal/geometry/equiv.py
+++ b/kristal/geometry/equiv.py
@@ -11,7 +11,7 @@ def sin2(x):
     """Shortcut for computing :code:`np.sin(x) ** 2`."""
     return sin(x) ** 2
 
-class SkewCoordinateSystem(object):
+class FractionalCoordinateSystem(object):
     """Class representing fractional coordinates system.
 
     :ivar a: length of first periodic vector.

--- a/kristal/geometry/equiv.py
+++ b/kristal/geometry/equiv.py
@@ -1,17 +1,13 @@
-#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
-"""
-Created on Wed Dec 19 12:44:19 2018
-
-@author: magdalenakrzus
-"""
 import numpy as np
 from numpy import sin, cos
 
 def cos2(x):
+    """Shortcut for computing `np.cos(x) ** 2`."""
     return cos(x) ** 2
 
 def sin2(x):
+    """Shortcut for computing `np.sin(x) ** 2`."""    
     return sin(x) ** 2
 
 class SkewCoordinateSystem(object):

--- a/kristal/geometry/equiv.py
+++ b/kristal/geometry/equiv.py
@@ -1,18 +1,46 @@
 # -*- coding: utf-8 -*-
+"""Various utilities for working with atoms' equivalence positions."""
 import numpy as np
 from numpy import sin, cos
 
 def cos2(x):
-    """Shortcut for computing `np.cos(x) ** 2`."""
+    """Shortcut for computing :code:`np.cos(x) ** 2`."""
     return cos(x) ** 2
 
 def sin2(x):
-    """Shortcut for computing `np.sin(x) ** 2`."""    
+    """Shortcut for computing :code:`np.sin(x) ** 2`."""
     return sin(x) ** 2
 
 class SkewCoordinateSystem(object):
-    """Class representing skew coordinates system."""
+    """Class representing fractional coordinates system.
+
+    :ivar a: length of first periodic vector.
+    :vartype a: float
+    :ivar b: length of second periodic vector.
+    :vartype b: float
+    :ivar c: length of second periodic vector.
+    :vartype c: float
+    :ivar alpha: an angle between second and third periodic vector.
+    :vartype alpha: float
+    :ivar beta: an angle between first and third periodic vector.
+    :vartype beta: float
+    :ivar gamma: an angle between first and second periodic vector.
+    :vartype gamma: float
+    :param a: length of first periodic vector.
+    :type a: float
+    :param b: length of second periodic vector.
+    :type b: float
+    :param c: length of second periodic vector.
+    :type c: float
+    :param alpha: an angle between second and third periodic vector.
+    :type alpha: float
+    :param beta: an angle between first and third periodic vector.
+    :type beta: float
+    :param gamma: an angle between first and second periodic vector.
+    :type gamma: float
+    """
     # pylint: disable=invalid-name
+
     def __init__(self, a, b, c, alpha, beta, gamma):
         self.a = a
         self.b = b
@@ -23,18 +51,46 @@ class SkewCoordinateSystem(object):
 
     @property
     def unit_cell_volume(self):
-        """Volume of the cell in this coordinates system."""
+        """Volume of the cell in this coordinates system.
+
+        Volume of the unit cell is defined as a volume of parallelepiped
+        determined by periodic vectors and is given by:
+
+        .. math::
+          V = abc \\sqrt{1 - \\cos^2(\\alpha) - \\cos^2(\\beta) - \\cos^2(\\gamma) + 2\\cos(\\alpha)\\cos(\\beta) \\cos(\\gamma)}
+        """
         return (self.a * self.b * self.c *
                 (1 - cos2(self.alpha) - cos2(self.beta) - cos2(self.gamma) +
                  2 * cos(self.alpha) * cos(self.beta) * cos(self.gamma)) ** 0.5)
 
     def change_of_basis_matrix(self):
-        """Matrix changing basis from Cartesian to this system."""
+        r"""Change of basis matrix from fractional to Cartesian coordinates.
+
+        Let :math:`(u, v, w)` be components of arbitrary vector in fractional coordinates.
+        Components of this vector in Cartesian coordinates are given by
+
+        .. math::
+          \begin{bmatrix} x \\ y \\ z \end{bmatrix} = M \cdot \begin{bmatrix} u \\ v \\ w \end{bmatrix}
+
+        where :math:`M` is given by
+
+        .. math::
+          M = \begin{bmatrix}
+            a & b \cos(\gamma) & c \cos(\beta) \\
+            0 & b \sin(\gamma) & c \frac{\cos(\alpha) - \cos(\beta)\cos(\gamma)}{\sin(\gamma)} \\
+            0 & 0 & \frac{V}{ab \sin(\gamma)}
+          \end{bmatrix}
+
+        This method returns :math:`M` from the above equation.
+        """
         return np.array([
             [self.a, self.b * cos(self.gamma), self.c * cos(self.beta)],
             [0, self.b * sin(self.gamma), self.c * (cos(self.alpha) - cos(self.beta) * cos(self.gamma)) / sin(self.gamma)],
             [0, 0, self.unit_cell_volume / self.a / self.b / sin(self.gamma)]])
 
     def inv_change_of_basis_matrix(self):
-        """"Matrix changing basis from this system to Cartesian."""
+        """"Matrix changing basis from this system to Cartesian.
+
+        This is an inverse of a matrix :math:`M` returned by :py:func:`change_of_basis_matrix`.
+        """
         return np.linalg.inv(self.change_of_basis_matrix())

--- a/tests/test_coordinate_system.py
+++ b/tests/test_coordinate_system.py
@@ -6,10 +6,10 @@ Created on Wed Dec 19 18:26:08 2018
 @author: magdalenakrzus
 """
 import numpy as np
-from kristal.geometry.equiv import SkewCoordinateSystem
+from kristal.geometry.equiv import FractionalCoordinateSystem
 
 def test_cartesian_system():
     """SkewCoordinateSystem should act as Cartesian one for straight angles nad unit lengths."""
-    system = SkewCoordinateSystem(1, 1, 1, np.pi / 2, np.pi / 2, np.pi / 2)
+    system = FractionalCoordinateSystem(1, 1, 1, np.pi / 2, np.pi / 2, np.pi / 2)
     assert np.allclose(system.change_of_basis_matrix(), np.eye(3))
     assert np.allclose(system.inv_change_of_basis_matrix(), np.eye(3))


### PR DESCRIPTION
This implemnets the following changes:
- Change name of `SkewCoordinateSystem` class to `FractionalCoordinateSystem`
- Add docstrings and documentation files for `kristal.grammar` package