### PR TITLE
Implement handling standard uncertainties

### DIFF
--- a/kristal/io/cifgrammar.lark
+++ b/kristal/io/cifgrammar.lark
@@ -5,9 +5,9 @@ loop : loop_header loop_body
 loop_header : "loop_" _NEWLINE (tag _NEWLINE)+
 loop_body : (_value _WS)+
 tag : "_" NON_BLANK_STRING
-_value : number | string
+_value : _number | string
 entry : tag _WS _value _NEWLINE
-number : ( integer | float) _UNCERTAINITY?
+_number : ( integer | float) _UNCERTAINITY?
 integer.3 : INTEGER
 float.2 : FLOAT
 string : _unquoted_string | _multiline_string | _quoted_string

--- a/kristal/io/cifgrammar.lark
+++ b/kristal/io/cifgrammar.lark
@@ -5,8 +5,9 @@ loop : loop_header loop_body
 loop_header : "loop_" _NEWLINE (tag _NEWLINE)+
 loop_body : (_value _WS)+
 tag : "_" NON_BLANK_STRING
-_value : integer | float | string
+_value : number | string
 entry : tag _WS _value _NEWLINE
+number : ( integer | float) _UNCERTAINITY?
 integer.3 : INTEGER
 float.2 : FLOAT
 string : _unquoted_string | _multiline_string | _quoted_string
@@ -30,6 +31,7 @@ BASE_STRING : ORDINARY_CHAR+
 FLOAT : ( INTEGER EXPONENT ) | ( ( "+" | "-" )? (( DIGIT* "." UNSIGNEDINTEGER ) | ( DIGIT+ "." )) EXPONENT? )
 EXPONENT : ("e"| "E") ( "+" | "-" )? UNSIGNEDINTEGER
 INTEGER : ( "+" | "-" )? UNSIGNEDINTEGER
+_UNCERTAINITY : "(" UNSIGNEDINTEGER ")"
 UNSIGNEDINTEGER : DIGIT+
 
 COMMENT: /#[^\r\n]*/


### PR DESCRIPTION
Our current implementation of CIF grammar does not handle numbers with attached standard uncertainties. This fix allows such numbers to be accepted, both in floating point and integer case. The parsed uncertainty is discarded, but we can later change the implementation if some meaningful handling is required.