### PR TITLE
Doc/cif file reading notebook

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -39,6 +39,7 @@ release = ''
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'nbsphinx',
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'sphinx.ext.coverage',

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -68,7 +68,7 @@ language = None
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store', '**.ipynb_checkpoints']
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = None

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -13,7 +13,8 @@ Kristal is an user friendly package for matching crystallographic structures.
    :maxdepth: 2
 
    userdocs/installation
-   
+   notebooks/reading-cif-files.ipynb
+
 .. toctree::
    :caption: Technical reference
    :maxdepth: 4

--- a/doc/notebooks/reading-cif-files.ipynb
+++ b/doc/notebooks/reading-cif-files.ipynb
@@ -1,0 +1,612 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Reading CIF files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Introduction\n",
+    "In this example we will see how to load a CIF file and access information stored inside it. For brevity we will use $B_2Mg$ CIF file available at http://crystallography-online.com/structure/1000026. Let us assume that the file is saved as `B2Mg.cif` in current directory (otherwise change the below variable to point to the right path)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "B2MG_CIF_FILE = 'B2Mg.cif'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here are the raw contents of the he file for easy reference:\n",
+    "```text\n",
+    "#------------------------------------------------------------------------------\n",
+    "#$Date: 2016-02-14 15:26:36 +0100 (Sun, 14 Feb 2016) $\n",
+    "#$Revision: 176435 $\n",
+    "#$URL: svn://www.crystallography.net/cod/cif/1/00/00/1000026.cif $\n",
+    "#------------------------------------------------------------------------------\n",
+    "#\n",
+    "# This file is available in the Crystallography Open Database (COD),\n",
+    "# http://www.crystallography.net/\n",
+    "#\n",
+    "# All data on this site have been placed in the public domain by the\n",
+    "# contributors.\n",
+    "#\n",
+    "data_1000026\n",
+    "_journal_coden_ASTM              JAPUAW\n",
+    "_journal_name_full               'J. Appl. Chem. USSR, engl. trans.'\n",
+    "_journal_page_first              970\n",
+    "_journal_page_last               974\n",
+    "_journal_volume                  44\n",
+    "_journal_year                    1971\n",
+    "_chemical_formula_sum            'B2 Mg'\n",
+    "_space_group_IT_number           191\n",
+    "_symmetry_cell_setting           hexagonal\n",
+    "_symmetry_Int_Tables_number      191\n",
+    "_symmetry_space_group_name_Hall  '-P 6 2'\n",
+    "_symmetry_space_group_name_H-M   'P 6/m m m'\n",
+    "_audit_creation_date             2002-02-11\n",
+    "_cell_angle_alpha                90\n",
+    "_cell_angle_beta                 90\n",
+    "_cell_angle_gamma                120.\n",
+    "_cell_formula_units_Z            1\n",
+    "_cell_length_a                   3.085\n",
+    "_cell_length_b                   3.085\n",
+    "_cell_length_c                   3.523\n",
+    "_cell_volume                     29.04\n",
+    "_cod_original_formula_sum        'Mg B2'\n",
+    "_cod_database_code               1000026\n",
+    "loop_\n",
+    "_symmetry_equiv_pos_as_xyz\n",
+    "x,y,z\n",
+    "-y,x-y,z\n",
+    "-x+y,-x,z\n",
+    "-x,-y,z\n",
+    "y,-x+y,z\n",
+    "x-y,x,z\n",
+    "y,x,-z\n",
+    "x-y,-y,-z\n",
+    "-x,-x+y,-z\n",
+    "-y,-x,-z\n",
+    "-x+y,y,-z\n",
+    "x,x-y,-z\n",
+    "-x,-y,-z\n",
+    "y,-x+y,-z\n",
+    "x-y,x,-z\n",
+    "x,y,-z\n",
+    "-y,x-y,-z\n",
+    "-x+y,-x,-z\n",
+    "-y,-x,z\n",
+    "-x+y,y,z\n",
+    "x,x-y,z\n",
+    "y,x,z\n",
+    "x-y,-y,z\n",
+    "-x,-x+y,z\n",
+    "loop_\n",
+    "_atom_site_label\n",
+    "_atom_site_symmetry_multiplicity\n",
+    "_atom_site_Wyckoff_symbol\n",
+    "_atom_site_fract_x\n",
+    "_atom_site_fract_y\n",
+    "_atom_site_fract_z\n",
+    "_atom_site_occupancy\n",
+    "_atom_site_type_symbol\n",
+    "Mg 1 a 0 0 0 1 Mg\n",
+    "B 2 d 0.3333 0.6667 0.5000 1 B\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Importing necessary stuff\n",
+    "The only thing that we need to import in order to read our CIF file is the `kristal.io.read_cif` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from kristal.io import read_cif"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Reading file and accessing data blocks\n",
+    "The basic invocation of `read_cif` requires only a single parameter - a path of the CIF file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "b2mg_data = read_cif(B2MG_CIF_FILE)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The returned value is a dictionary keyed with data block names. Let's verify that the only data block present in the file was read by Kristal. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "dict_keys(['1000026'])\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(b2mg_data.keys())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Accessing data in the data blocks\n",
+    "Values of the `b2mg_data` dict are instances of `DataBlock` namedtuple. They have the following attributes:\n",
+    "\n",
+    "- `name`: name of the data block (this is the same as the key corresponding to the data block)\n",
+    "- `loops`: a list of loops found in the file. Contents of each loop are stored inside `pandas.DataFrame`\n",
+    "- `entries`: other entries from the CIF file, storead as `pandas.Series`. Most of the time you can use this attribute like a dictionary.\n",
+    "\n",
+    "Let's access some data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'1000026'"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "datablock = b2mg_data['1000026']\n",
+    "datablock.name"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Accessing entries\n",
+    "Let us first see how one can access data entries. As already mentioned, they can be accessed in a dictionary-like fashion. For example, the below code displays all cell angles."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "90\n",
+      "90\n",
+      "120.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "for key in ['cell_angle_alpha', 'cell_angle_beta', 'cell_angle_gamma']:\n",
+    "    print(datablock.entries[key])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "One can easily access names of all available entries using `datablock.entries.index` attribute."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Index(['journal_coden_ASTM', 'journal_name_full', 'journal_page_first',\n",
+       "       'journal_page_last', 'journal_volume', 'journal_year',\n",
+       "       'chemical_formula_sum', 'space_group_IT_number',\n",
+       "       'symmetry_cell_setting', 'symmetry_Int_Tables_number',\n",
+       "       'symmetry_space_group_name_Hall', 'symmetry_space_group_name_H-M',\n",
+       "       'audit_creation_date', 'cell_angle_alpha', 'cell_angle_beta',\n",
+       "       'cell_angle_gamma', 'cell_formula_units_Z', 'cell_length_a',\n",
+       "       'cell_length_b', 'cell_length_c', 'cell_volume',\n",
+       "       'cod_original_formula_sum', 'cod_database_code'],\n",
+       "      dtype='object')"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "datablock.entries.index"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that Kristal does its best to detect type of items stored in CIF file and convert them accordingly. Let's print cell angles again, this times showing the corresponding type."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "cell_angle_alpha 90 <class 'int'>\n",
+      "cell_angle_beta 90 <class 'int'>\n",
+      "cell_angle_gamma 120.0 <class 'float'>\n"
+     ]
+    }
+   ],
+   "source": [
+    "for key in ['cell_angle_alpha', 'cell_angle_beta', 'cell_angle_gamma']:\n",
+    "    angle = datablock.entries[key]\n",
+    "    print('{0} {1} {2}'.format(key, angle, type(angle)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As wee see Kristal tries to match as specific type as possible. In the above example $\\alpha$ and $\\beta$ angles were read as integers since they consist only of digits. On the other hand $\\gamma$ angle was read as a floating point number since it contained decimal point."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Remember that the entries are stored inside a `pandas.Series` instance. This allows us to use all of the nice features pandas has to offer, like subsetting. For example, we can easily access all entries containing information relevant to unit cell geometry in the following way:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "cell_angle_alpha           90\n",
+       "cell_angle_beta            90\n",
+       "cell_angle_gamma          120\n",
+       "cell_formula_units_Z        1\n",
+       "cell_length_a           3.085\n",
+       "cell_length_b           3.085\n",
+       "cell_length_c           3.523\n",
+       "cell_volume             29.04\n",
+       "dtype: object"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "datablock.entries[datablock.entries.index.str.startswith('cell')]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Accessing loops\n",
+    "Accessing loops is as simple as accessing data entries. Let's see content of the second loop."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>atom_site_label</th>\n",
+       "      <th>atom_site_symmetry_multiplicity</th>\n",
+       "      <th>atom_site_Wyckoff_symbol</th>\n",
+       "      <th>atom_site_fract_x</th>\n",
+       "      <th>atom_site_fract_y</th>\n",
+       "      <th>atom_site_fract_z</th>\n",
+       "      <th>atom_site_occupancy</th>\n",
+       "      <th>atom_site_type_symbol</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Mg</td>\n",
+       "      <td>1</td>\n",
+       "      <td>a</td>\n",
+       "      <td>0.0000</td>\n",
+       "      <td>0.0000</td>\n",
+       "      <td>0.0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>Mg</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>B</td>\n",
+       "      <td>2</td>\n",
+       "      <td>d</td>\n",
+       "      <td>0.3333</td>\n",
+       "      <td>0.6667</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>1</td>\n",
+       "      <td>B</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  atom_site_label  atom_site_symmetry_multiplicity atom_site_Wyckoff_symbol  \\\n",
+       "0              Mg                                1                        a   \n",
+       "1               B                                2                        d   \n",
+       "\n",
+       "   atom_site_fract_x  atom_site_fract_y  atom_site_fract_z  \\\n",
+       "0             0.0000             0.0000                0.0   \n",
+       "1             0.3333             0.6667                0.5   \n",
+       "\n",
+       "   atom_site_occupancy atom_site_type_symbol  \n",
+       "0                    1                    Mg  \n",
+       "1                    1                     B  "
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "datablock.loops[1]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As with `entries`, we can use all of the pandas magic. For instance, choosing only interesting columns is easy. Let's display atom labels along with their position in fractional coordinates."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>atom_site_label</th>\n",
+       "      <th>atom_site_fract_x</th>\n",
+       "      <th>atom_site_fract_y</th>\n",
+       "      <th>atom_site_fract_z</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>Mg</td>\n",
+       "      <td>0.0000</td>\n",
+       "      <td>0.0000</td>\n",
+       "      <td>0.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>B</td>\n",
+       "      <td>0.3333</td>\n",
+       "      <td>0.6667</td>\n",
+       "      <td>0.5</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  atom_site_label  atom_site_fract_x  atom_site_fract_y  atom_site_fract_z\n",
+       "0              Mg             0.0000             0.0000                0.0\n",
+       "1               B             0.3333             0.6667                0.5"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "datablock.loops[1][['atom_site_label', 'atom_site_fract_x', 'atom_site_fract_y', 'atom_site_fract_z']]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Or, maybe you are interested in data corresponding to particular element?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>atom_site_label</th>\n",
+       "      <th>atom_site_symmetry_multiplicity</th>\n",
+       "      <th>atom_site_Wyckoff_symbol</th>\n",
+       "      <th>atom_site_fract_x</th>\n",
+       "      <th>atom_site_fract_y</th>\n",
+       "      <th>atom_site_fract_z</th>\n",
+       "      <th>atom_site_occupancy</th>\n",
+       "      <th>atom_site_type_symbol</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>B</td>\n",
+       "      <td>2</td>\n",
+       "      <td>d</td>\n",
+       "      <td>0.3333</td>\n",
+       "      <td>0.6667</td>\n",
+       "      <td>0.5</td>\n",
+       "      <td>1</td>\n",
+       "      <td>B</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  atom_site_label  atom_site_symmetry_multiplicity atom_site_Wyckoff_symbol  \\\n",
+       "1               B                                2                        d   \n",
+       "\n",
+       "   atom_site_fract_x  atom_site_fract_y  atom_site_fract_z  \\\n",
+       "1             0.3333             0.6667                0.5   \n",
+       "\n",
+       "   atom_site_occupancy atom_site_type_symbol  \n",
+       "1                    1                     B  "
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "datablock.loops[1].query('atom_site_label==\"B\"')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Acknowledgements\n",
+    "For parsing CIF files Kristal uses [Lark](https://github.com/lark-parser/lark), an excellent library for parsing arbitrary context free grammars."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This improves user documentation by adding examples of using `kristal.io` module. The following changes are included:

- Jupyter notebook showcasing usage of `kristal.io` for reading CIF file and accessing data in it
- Inclusion of the above notebook in the user documentation (so the same example is also available ad readthedocs). 