### PR TITLE
Fix/quoted strings

### DIFF
--- a/kristal/io/transform.py
+++ b/kristal/io/transform.py
@@ -55,6 +55,14 @@ class CIFTransformer(lark.Transformer):
         """Transform string."""
         return str(matches[0])
 
+    def single_quoted_string(self, matches):
+        """Transform single quoted string."""
+        return matches[0][1:-1]
+
+    def double_quoted_string(self, matches):
+        """Transform double quoted string."""
+        return matches[0][1:-1]
+
     def tag(self, matches):
         """Transform tag."""
         return str(matches[0])

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -25,6 +25,28 @@ def test_string_transform(transformer):
     assert transformer.string([Token('NON_BLANK_STRING', 'Bozon')]) == 'Bozon'
 
 @pytest.mark.parametrize(
+    'original,expected',
+    [["'Benzen'", 'Benzen'],
+     ["'Benzen''", "Benzen'"],
+     ["''Benzen'", "'Benzen"],
+     ["'Test'test'", "Test'test"]])
+def test_single_quoted_string_transform(original, expected, transformer):
+    """CIFTransformer should correctly strip single quoted strings."""
+    token = Token('SINGLE_QUOTED_STRING_INNER', original)
+    assert transformer.single_quoted_string([token]) == expected
+
+@pytest.mark.parametrize(
+    'original,expected',
+    [['"Benzen"', 'Benzen'],
+     ['"Benzen""', 'Benzen"'],
+     ['""Benzen"', '"Benzen'],
+     ['"Test"test"', 'Test"test']])
+def test_double_quoted_string_transform(original, expected, transformer):
+    """CIFTransformer should correctly strip double quoted strings."""
+    token = Token('DOUBLE_QUOTED_STRING_INNER', original)
+    assert transformer.double_quoted_string([token]) == expected
+
+@pytest.mark.parametrize(
     'float_str,expected',
     [['21.37', 21.37],
      ['2.1e-2', 0.021],


### PR DESCRIPTION
Currently quoted strings are not transformed in any way, resulting in incorrect input that includes (e.g. containing the Token('UNQUOTED_STRING_INNER', ...) string). This PR solves this by adding transformation rules for both single and double quoted strings.